### PR TITLE
SELECT/ESCAPE now bound to PSX SELECT

### DIFF
--- a/src/port/sdl/port.cpp
+++ b/src/port/sdl/port.cpp
@@ -460,7 +460,7 @@ static struct {
 	{ SDLK_LALT,		DKEY_CROSS },
 	{ SDLK_TAB,		DKEY_L1 },
 	{ SDLK_BACKSPACE,	DKEY_R1 },
-	//{ SDLK_ESCAPE,		DKEY_SELECT },
+	{ SDLK_ESCAPE,		DKEY_SELECT },
 #else
 	{ SDLK_a,		DKEY_SQUARE },
 	{ SDLK_x,		DKEY_CIRCLE },


### PR DESCRIPTION
This was commented out and initially replaced with PSX select being SELECT/ESCAPE + B/LEFT ALT. However, that keybind prevented being able to use PSX L2/R2 + Cross (notably needed in Oddworld: Abe's Exoddus), so it was removed. This in turn left PSX select unbound, so the easiest solution is to just rebind SELECT.

A quirk of this is not being able to press PSX SELECT + L1/R1, however this is most likely not a key combo used in any PSX game, so I deem it acceptable.

OPK attached.
[pcsx4all.zip](https://github.com/retrofw/pcsx4all/files/5239583/pcsx4all.zip)
